### PR TITLE
Feat/manifest

### DIFF
--- a/src/manifest.development.json
+++ b/src/manifest.development.json
@@ -8,7 +8,7 @@
     "host_permissions": [
         "https://froggo.platan.us/*",
     ],
-    "version": "0.0.1",
+    "version": "0.2.0",
     "action": {
         "default_popup": "popup.html"
     }

--- a/src/manifest.production.json
+++ b/src/manifest.production.json
@@ -8,7 +8,7 @@
     "host_permissions": [
         "https://froggo.platan.us/*"
     ],
-    "version": "0.0.1",
+    "version": "0.2.0",
     "action": {
         "default_popup": "popup.html"
     }


### PR DESCRIPTION
### Contexto
Se está creando el nuevo repo de la extensión de Froggo dado que la extensión del [repo anterior](https://github.com/platanus/froggo-ext) tenía varios problemas de base (se debía migrar el manifest v2 a v3 para subir la ext a la Chrome Web Store, pero en el proceso se rompieron unos plugins necesarios construir la extensión).
Se optó por crear la extensión desde cero usando vue-cli-plugin-chrome-extension-cli que funciona por defecto con el manifest v3, y luego ir migrando el código de los componentes de Vue.

### Qué se está haciendo
- Se agregan los permisos necesarios para acceder a la api de Froggo y copiar texto al clipboard.
- Se actualiza la versión de la extensión a 0.2.0